### PR TITLE
Deleted __cmp__() functions from comtypes

### DIFF
--- a/comtypes/GUID.py
+++ b/comtypes/GUID.py
@@ -42,11 +42,6 @@ class GUID(Structure):
 
     __str__ = __unicode__
 
-    def __cmp__(self, other):
-        if isinstance(other, GUID):
-            return cmp(binary(self), binary(other))
-        return -1
-
     def __bool__(self):
         return self != GUID_null
 

--- a/comtypes/__init__.py
+++ b/comtypes/__init__.py
@@ -589,21 +589,6 @@ class _compointer_base(c_void_p, metaclass=_compointer_meta):
                 _debug("Release %s", self)
                 self.Release()
 
-    def __cmp__(self, other):
-        """Compare pointers to COM interfaces."""
-        # COM identity rule
-        #
-        # XXX To compare COM interface pointers, should we
-        # automatically QueryInterface for IUnknown on both items, and
-        # compare the pointer values?
-        if not isinstance(other, _compointer_base):
-            return 1
-
-        # get the value property of the c_void_p baseclass, this is the pointer value
-        return cmp(
-            super(_compointer_base, self).value, super(_compointer_base, other).value
-        )
-
     def __eq__(self, other):
         if not isinstance(other, _compointer_base):
             return False

--- a/comtypes/client/lazybind.py
+++ b/comtypes/client/lazybind.py
@@ -126,11 +126,6 @@ class Dispatch(object):
         "QueryInterface is forwarded to the real com object."
         return self._comobj.QueryInterface(*args)
 
-    def __cmp__(self, other):
-        if not isinstance(other, Dispatch):
-            return 1
-        return cmp(self._comobj, other._comobj)
-
     def __eq__(self, other):
         return isinstance(other, Dispatch) and self._comobj == other._comobj
 


### PR DESCRIPTION
Deleted __cmp__ functions from comtypes as stated in issue #512 as they are no longer supported.