### PR TITLE
Removed from __future__ import print_function

### DIFF
--- a/comtypes/client/_events.py
+++ b/comtypes/client/_events.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ctypes
 import traceback
 import comtypes

--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ctypes
 import importlib
 import logging

--- a/comtypes/shelllink.py
+++ b/comtypes/shelllink.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from ctypes import *
 from ctypes.wintypes import DWORD, WIN32_FIND_DATAA, WIN32_FIND_DATAW, MAX_PATH
 from comtypes import IUnknown, GUID, COMMETHOD, HRESULT, CoClass

--- a/comtypes/test/__init__.py
+++ b/comtypes/test/__init__.py
@@ -1,6 +1,5 @@
 # comtypes.test package.
 
-from __future__ import print_function
 import ctypes
 import getopt
 import os

--- a/comtypes/test/find_memleak.py
+++ b/comtypes/test/find_memleak.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest, gc
 from ctypes import *
 from ctypes.wintypes import *

--- a/comtypes/test/test_agilent.py
+++ b/comtypes/test/test_agilent.py
@@ -2,7 +2,6 @@
 # is installed.  It is not requires to have a physical instrument
 # connected, the driver is used in simulation mode.
 
-from __future__ import print_function
 import unittest
 from comtypes.test import ResourceDenied
 from comtypes.client import CreateObject

--- a/comtypes/test/test_createwrappers.py
+++ b/comtypes/test/test_createwrappers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import glob
 import os

--- a/comtypes/test/test_excel.py
+++ b/comtypes/test/test_excel.py
@@ -1,5 +1,4 @@
 # -*- coding: latin-1 -*-
-from __future__ import print_function
 
 import datetime
 import unittest

--- a/comtypes/test/test_variant.py
+++ b/comtypes/test/test_variant.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import datetime
 import decimal

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -1,6 +1,5 @@
 # Code generator to generate code for everything contained in COM type
 # libraries.
-from __future__ import print_function
 import ctypes
 import keyword
 import logging

--- a/comtypes/tools/tlbparser.py
+++ b/comtypes/tools/tlbparser.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 from typing import (


### PR DESCRIPTION
Removed from __future__ import print_function as stated in task #464 as it is no longer needed if only Python 3 is supported.